### PR TITLE
Downloads: Rework copy

### DIFF
--- a/components/disclaimer.vue
+++ b/components/disclaimer.vue
@@ -1,26 +1,31 @@
 <template>
   <div>
     <p>
-      These are <strong>pre-release</strong> daily builds of elementary OS.
-      Things will be broken. Please see the
-      <a href="https://github.com/orgs/elementary/projects/55" rel="noopener" target="_blank">6.0 Release GitHub Project</a>
-      for a full list of tasks and regressions. Current major issues with these
-      images may include, but are not limited to:
+      These are <strong>pre-release</strong> daily development builds of elementary OS.
+      Current major known issues include, but are not limited to:
     </p>
 
     <ul>
-      <li>May require Internet to install</li>
-      <li>Full-disk encryption may lead to a non-bootable install</li>
+      <li>Installation failures while installing offline or with full-disk encryption</li>
       <li>Curated apps are not available in AppCenter</li>
-      <li>Dark style support is unfinished</li>
-      <li>System stylesheet is unfinished</li>
-      <li>General features, APIs are <strong>not finalized</strong></li>
+      <li>Look & feel issues, including unfinished dark mode support</li>
+      <li>General features and APIs are <strong>not finalized</strong></li>
     </ul>
 
     <p>
-      While these issues are expected to be resolved before a stable release of
-      elementary OS 6, their existence now and the generally unfinished state
-      mean <strong>do not use these images on a production system</strong>.
+      Please see the
+      <a href="https://github.com/orgs/elementary/projects/55" rel="noopener" target="_blank">6.0 Release GitHub Project</a>
+      for a full list of outstanding tasks and regressions.
+    </p>
+
+    <p>
+      These issues, and more, are expected to be resolved before a stable release of elementary OS 6.
+      Until that time, <strong>do not use these images on a production system</strong>.
+    </p>
+
+    <p>
+      <strong>Please refrain from publishing reviews or other in-depth looks of early access builds.</strong>
+      We're excited that you're excited, but formally presenting unfinished products can damage our reputation. If you'd like to share informally, we'd appreciate a focus on features rather than quality or performance, which will change before release.
     </p>
   </div>
 </template>

--- a/components/disclaimer.vue
+++ b/components/disclaimer.vue
@@ -8,7 +8,7 @@
     <ul>
       <li>Installation failures while installing offline or with full-disk encryption</li>
       <li>Curated apps are not available in AppCenter</li>
-      <li>Look & feel issues, including unfinished dark mode support</li>
+      <li>Look &amp; feel issues, including unfinished dark style support</li>
       <li>General features and APIs are <strong>not finalized</strong></li>
     </ul>
 

--- a/pages/downloads.vue
+++ b/pages/downloads.vue
@@ -24,7 +24,7 @@
           class="button suggested"
           :href="latestDaily | isoUrl"
         >
-          Download {{ latestDaily | name }} ({{ latestDaily | size }} GB)
+          Download ({{ latestDaily | size }} GB)
         </a>
       </div>
     </template>

--- a/pages/downloads.vue
+++ b/pages/downloads.vue
@@ -8,8 +8,8 @@
 
     <template v-if="latestDaily">
       <p>
-        The latest build occured on {{
-          latestDaily | relativeDate }}. If this build does not install or
+        <code>{{ latestDaily | name }}</code> was built {{
+          latestDaily | relativeDate }}. If it does not install or
         otherwise work for you, try a previous build.
       </p>
 

--- a/pages/downloads.vue
+++ b/pages/downloads.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <h1>elementary OS Daily Builds</h1>
+    <h1>elementary OS Early Access Builds</h1>
 
     <disclaimer />
 
@@ -8,11 +8,10 @@
 
     <template v-if="latestDaily">
       <p>
-        Download <code>{{ latestDaily | name }}</code>, which was built {{
+        The latest build occured on {{
           latestDaily | relativeDate }}. If this build does not install or
         otherwise work for you, try a previous build.
       </p>
-      <p>As this is a <strong>pre-release</strong> build, we ask that you refrain from sharing “reviews” or other in-depth looks at elementary OS in this state. Daily builds are intended for developers and dedicated testers, but it is best to maintain a sense of surprise for end users with the stable release.</p>
 
       <div class="center">
         <a
@@ -25,7 +24,7 @@
           class="button suggested"
           :href="latestDaily | isoUrl"
         >
-          Download ({{ latestDaily | size }} GB)
+          Download {{ latestDaily | name }} ({{ latestDaily | size }} GB)
         </a>
       </div>
     </template>


### PR DESCRIPTION
The current copy on the downloads page comes across as a bit of a wall of text to me. This is problematic because we really want people to read this stuff. So I:

* Used the phrase "Early Access" to emphasize the exclusiveness and not-ready-ness
* Generally tried to use fewer words
* Combined a couple of bullet points. Specifically with the installer and look and feel. Hopefully the first couple works in these bullets can be understood even if the user doesn't read the whole thing, so they at least get the idea while skimming
* Moved the 6.0 release project below the bullets since it's kind of a "And more"
* Moved the review stuff from the downloads part into the disclaimer part since it was kind of duplicating copy and felt weird detached from the other disclaimer stuff
* Bold that "Please don't" line
* Try to be nice but realistic about sharing. People are gonna share. But letting them know how their sharing could hurt and trying to be more specific about what we don't want them to share about and a good way to share is probably good
* Take the file name out that body copy and stick it in the button so the build date is more obvious and the download button says what you're downloading