### PR TITLE
Remove node setup for publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,14 +16,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Setup Node
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12'
-
-      - name: Install
-        run: npm ci
-
       - name: Build
         run: docker build -t elementary/builds .
 


### PR DESCRIPTION
All of the installing and node stuff happens in docker, so this is not needed