### PR TITLE
Collapse previous build sections

### DIFF
--- a/assets/styles/layout.scss
+++ b/assets/styles/layout.scss
@@ -63,3 +63,30 @@ table {
       }
   }
 }
+
+details summary {
+  color: var(--accent-color);
+  cursor: default;
+}
+
+details summary:hover,
+details summary:focus {
+  outline: none;
+}
+
+details summary::marker,
+::-webkit-details-marker {
+  content: "";
+  display: none;
+}
+
+details summary >::after {
+  content: "▸";
+  display: inline-block;
+  margin-left: 0.5em;
+  transition: transform 250ms ease;
+}
+
+details[open] summary ::after {
+  transform: rotate(90deg);
+}

--- a/pages/downloads.vue
+++ b/pages/downloads.vue
@@ -95,117 +95,129 @@
     </p>
 
     <template v-if="oldDailies.length > 0">
-      <h3 id="oldDailies">
-        64-bit AMD/Intel
-      </h3>
-      <table>
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Checksum</th>
-            <th>Date</th>
-          </tr>
-        </thead>
+      <details>
+        <summary>
+          <h3 id="oldDailies">
+            64-bit AMD/Intel
+          </h3>
+        </summary>
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Checksum</th>
+              <th>Date</th>
+            </tr>
+          </thead>
 
-        <tbody>
-          <tr
-            v-for="iso in oldDailies"
-            :key="iso.path"
-          >
-            <td>
-              <a :href="iso | isoUrl">
-                {{ iso | name }}
-              </a>
-            </td>
+          <tbody>
+            <tr
+              v-for="iso in oldDailies"
+              :key="iso.path"
+            >
+              <td>
+                <a :href="iso | isoUrl">
+                  {{ iso | name }}
+                </a>
+              </td>
 
-            <td>
-              <a :href="iso | shaUrl">
-                SHA256
-              </a>
-            </td>
+              <td>
+                <a :href="iso | shaUrl">
+                  SHA256
+                </a>
+              </td>
 
-            <td>
-              {{ iso | relativeDate }}
-            </td>
-          </tr>
-        </tbody>
-      </table>
+              <td>
+                {{ iso | relativeDate }}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </details>
     </template>
 
     <template v-if="oldPinebooks.length > 0">
-      <h3 id="oldPinebooks">
-        Pinebook Pro
-      </h3>
-      <table>
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Checksum</th>
-            <th>Date</th>
-          </tr>
-        </thead>
+      <details>
+        <summary>
+          <h3 id="oldPinebooks">
+            Pinebook Pro
+          </h3>
+        </summary>
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Checksum</th>
+              <th>Date</th>
+            </tr>
+          </thead>
 
-        <tbody>
-          <tr
-            v-for="iso in oldPinebooks"
-            :key="iso.path"
-          >
-            <td>
-              <a :href="iso | isoUrl">
-                {{ iso | name }}
-              </a>
-            </td>
+          <tbody>
+            <tr
+              v-for="iso in oldPinebooks"
+              :key="iso.path"
+            >
+              <td>
+                <a :href="iso | isoUrl">
+                  {{ iso | name }}
+                </a>
+              </td>
 
-            <td>
-              <a :href="iso | shaUrl">
-                SHA256
-              </a>
-            </td>
+              <td>
+                <a :href="iso | shaUrl">
+                  SHA256
+                </a>
+              </td>
 
-            <td>
-              {{ iso | relativeDate }}
-            </td>
-          </tr>
-        </tbody>
-      </table>
+              <td>
+                {{ iso | relativeDate }}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </details>
     </template>
 
     <template v-if="oldRasPis.length > 0">
-      <h3 id="oldRasPis">
-        Raspberry Pi 4
-      </h3>
-      <table>
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Checksum</th>
-            <th>Date</th>
-          </tr>
-        </thead>
+      <details>
+        <summary>
+          <h3 id="oldRasPis">
+            Raspberry Pi 4
+          </h3>
+        </summary>
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Checksum</th>
+              <th>Date</th>
+            </tr>
+          </thead>
 
-        <tbody>
-          <tr
-            v-for="iso in oldRasPis"
-            :key="iso.path"
-          >
-            <td>
-              <a :href="iso | isoUrl">
-                {{ iso | name }}
-              </a>
-            </td>
+          <tbody>
+            <tr
+              v-for="iso in oldRasPis"
+              :key="iso.path"
+            >
+              <td>
+                <a :href="iso | isoUrl">
+                  {{ iso | name }}
+                </a>
+              </td>
 
-            <td>
-              <a :href="iso | shaUrl">
-                SHA256
-              </a>
-            </td>
+              <td>
+                <a :href="iso | shaUrl">
+                  SHA256
+                </a>
+              </td>
 
-            <td>
-              {{ iso | relativeDate }}
-            </td>
-          </tr>
-        </tbody>
-      </table>
+              <td>
+                {{ iso | relativeDate }}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </details>
     </template>
   </div>
 </template>


### PR DESCRIPTION
Simpler than and supersedes #57. Just using HTML here with a tiny bit of CSS to make it look a bit better. Hide whitespace changes to see the actual substantive changes.

We could still potentially do something like #57 within each section, but this is a start to making it not a wall of text.