### PR TITLE
Update store link in navbar to the new one

### DIFF
--- a/components/layout-navbar.vue
+++ b/components/layout-navbar.vue
@@ -21,7 +21,7 @@
         </li>
 
         <li>
-          <a href="https://elementary.io/store/" target="_self">Store</a>
+          <a href="https://store.elementary.io/" target="_self">Store</a>
         </li>
 
         <li>

--- a/components/layout-navbar.vue
+++ b/components/layout-navbar.vue
@@ -21,7 +21,7 @@
         </li>
 
         <li>
-          <a href="https://store.elementary.io/" target="_self">Store</a>
+          <a href="https://store.elementary.io" target="_self">Store</a>
         </li>
 
         <li>


### PR DESCRIPTION
The navbar link for the elementary Store was taking the user to the previous link which does not work anymore.

I updated the link to the new https://store.elementary.io/