### PR TITLE
add cf-connecting-ip to beta ip grab

### DIFF
--- a/server/beta.js
+++ b/server/beta.js
@@ -87,7 +87,7 @@ async function getRegion (ip) {
 }
 
 export default async (req, res, next) => {
-  const ip = req.headers['x-forwarded-for'] || req.connection.remoteAddress
+  const ip = req.headers['cf-connecting-ip'] || req.headers['x-forwarded-for'] || req.connection.remoteAddress
   const region = await getRegion(ip)
 
   const timestamp = (Date.now() / 1000).toFixed()


### PR DESCRIPTION
We are not checking the `cf-connecting-ip` header like the website repo. This should fix load balancing for downloads