### PR TITLE
Add stable ISOs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@
 
 ---
 
-This repository contains the website code for our daily builds. This **DOES
-NOT** build elementary OS or have any operating system related code.
+This repository contains the website code for our Early Access builds. This
+**DOES NOT** build elementary OS or have any operating system related code.
 
 ---
 

--- a/data/development-images.json
+++ b/data/development-images.json
@@ -363,5 +363,10 @@
     "path": "daily-rpi/elementaryos-6.0-daily-rpi-20201202.img.xz",
     "timestamp": "2020-12-02T00:41:37.811Z",
     "size": 2082964992
+  },
+  {
+    "path": "stable/elementaryos-6.0-stable.20210804-rc.iso",
+    "timestamp": "2021-08-04T00:16:37.811Z",
+    "size": 2422964992
   }
 ]

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -14,7 +14,7 @@ export default {
     meta: [
       { charset: 'utf-8' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },
-      { hid: 'description', name: 'description', content: 'Unstable and daily builds of elementary OS' }
+      { hid: 'description', name: 'description', content: 'Early Access builds of elementary OS' }
     ],
 
     link: [

--- a/pages/downloads.vue
+++ b/pages/downloads.vue
@@ -7,7 +7,28 @@
       and the next, but generally they should be safe to use.
     </p>
 
-    <p><strong>Coming Soon…</strong></p>
+    <template v-if="latestStable">
+      <h3>64-bit AMD/Intel</h3>
+      <p>
+        <code>{{ latestStable | name }}</code> was built {{
+          latestStable | relativeDate }}.
+      </p>
+
+      <div class="center">
+        <a
+          class="button"
+          :href="latestStable | shaUrl"
+        >
+          Download SHA256
+        </a>
+        <a
+          class="button suggested"
+          :href="latestStable | isoUrl"
+        >
+          Download ({{ latestStable | size }} GB)
+        </a>
+      </div>
+    </template>
 
     <h2>Daily Builds</h2>
 
@@ -277,6 +298,11 @@ export default {
   computed: {
     ...mapGetters('images', ['imagesFor']),
 
+    latestStable () {
+      const [latest] = this.imagesFor('stable')
+      return latest
+    },
+
     latestDaily () {
       const [latest] = this.imagesFor('daily')
       return latest
@@ -290,6 +316,11 @@ export default {
     latestRasPi () {
       const [latest] = this.imagesFor('daily-rpi')
       return latest
+    },
+
+    oldStables () {
+      const [, ...old] = this.imagesFor('stable')
+      return old
     },
 
     oldDailies () {


### PR DESCRIPTION
Fixes #51. Just shows the latest stable so far because I didn't want to make that page a huge mess, but also adds support to trivially display historical stable builds if/when we want to do that, too.