### PR TITLE
Include 7.0 images

### DIFF
--- a/data/development-images.json
+++ b/data/development-images.json
@@ -368,5 +368,25 @@
     "path": "stable/elementaryos-6.0-stable.20210804-rc.iso",
     "timestamp": "2021-08-04T00:16:37.811Z",
     "size": 2422964992
+  },
+  {
+    "path": "daily/elementaryos-7.0-daily.20211104.iso",
+    "timestamp": "2021-11-04T00:48:37.822Z",
+    "size": 2268439293
+  },
+  {
+    "path": "daily/elementaryos-6.0-daily.20211104.iso",
+    "timestamp": "2021-11-04T00:44:37.822Z",
+    "size": 2218439293
+  },
+  {
+    "path": "daily/elementaryos-7.0-daily.20211103.iso",
+    "timestamp": "2021-11-03T00:41:37.822Z",
+    "size": 2268439293
+  },
+  {
+    "path": "daily/elementaryos-6.0-daily.20211103.iso",
+    "timestamp": "2021-11-03T00:49:37.822Z",
+    "size": 2218439293
   }
 ]

--- a/store/images.js
+++ b/store/images.js
@@ -6,7 +6,7 @@ export const getters = {
   imagesFor: (state, getters) => (channel = 'daily') => {
     return getters.images
       .filter(({ path }) => path.startsWith(`${channel}/`))
-      .filter(({ path }) => path.includes('6.0'))
+      .filter(({ path }) => path.includes('6.0') || path.includes('7.0'))
   },
 
   images (state) {


### PR DESCRIPTION
I think it's probably still valuable to have 6.0 dailies building for testing of fixes that haven't hit stable yet, but I guess we could reduce the frequency of them.

This is the minimum we need to display the 7.0 dailies on the page, mixed in with the 6.0 ones. To more clearly differentiate them would probably need a whole redesign because the whole thing is becoming pretty unclear.