### PR TITLE
Update images.js for 8.0 daily builds

### DIFF
--- a/store/images.js
+++ b/store/images.js
@@ -6,7 +6,7 @@ export const getters = {
   imagesFor: (state, getters) => (channel = 'daily') => {
     return getters.images
       .filter(({ path }) => path.startsWith(`${channel}/`))
-      .filter(({ path }) => path.includes('6.0') || path.includes('6.1') || path.includes('7.0') || path.includes('7.1'))
+      .filter(({ path }) => path.includes('6.1') || path.includes('7.0') || path.includes('7.1') || path.includes('8.0'))
   },
 
   images (state) {


### PR DESCRIPTION
Also remove 6.0 images that we don't publish anymore to keep this line a bit shorter.

We have 8.0 builds available, but not really 8.0 because we're based on Ubuntu Mantic (23.10) for now, and currently not really working because we're not yet building the installer for Mantic.

Not sure if we want to publish these on the builds site, but might be useful for people to follow progress, or for other devs to download and test out?