### PR TITLE
Images: add 9.0, drop 8.0

### DIFF
--- a/store/images.js
+++ b/store/images.js
@@ -8,7 +8,7 @@ export const getters = {
       .filter(({ path }) => path.startsWith(`${channel}/`))
       // This filter allows us to build dailies for future releases internally before allowing them to be public.
       // It only modifies the images shown in the UI, not the actual images that are available for download.
-      .filter(({ path }) => path.includes('8.0') || path.includes('8.1'))
+      .filter(({ path }) => path.includes('8.1') || path.includes('9.0'))
   },
 
   images (state) {


### PR DESCRIPTION
- Add 9.0 images because now Daily OS 9 has been successfully uploaded: https://github.com/elementary/os/actions/runs/29628449831
- Drop 8.0 images which we no longer publish

I think OS 9 has not been ready for public tests yet but guess this allows us developers to test and work on OS 9 more? At the moment you need to build it locally if you want to test it.
