### PR TITLE
feat: add GitHub Sponsors dashboard link (#50)

### DIFF
--- a/components/layout-navbar.vue
+++ b/components/layout-navbar.vue
@@ -52,12 +52,17 @@
 
     <nav v-if="loggedIn" class="secondary">
       <ul>
-        <li>
-          <a @click="logout">
-            Log Out
-          </a>
-        </li>
-      </ul>
+              <li>
+                <a href="https://github.com/sponsors/elementary/dashboard" target="_blank" rel="noopener">
+                  Manage Sponsorship
+                </a>
+              </li>
+              <li>
+                <a @click="logout">
+                  Log Out
+                </a>
+              </li>
+            </ul>
     </nav>
   </header>
 </template>

--- a/components/layout-navbar.vue
+++ b/components/layout-navbar.vue
@@ -53,7 +53,7 @@
     <nav v-if="loggedIn" class="secondary">
       <ul>
         <li>
-          <a href="https://github.com/sponsors/elementary/dashboard" target="_blank" rel="noopener">
+          <a href="https://github.com/sponsors/elementary" target="_blank" rel="noopener">
             Manage Sponsorship
           </a>
         </li>

--- a/components/layout-navbar.vue
+++ b/components/layout-navbar.vue
@@ -52,17 +52,17 @@
 
     <nav v-if="loggedIn" class="secondary">
       <ul>
-              <li>
-                <a href="https://github.com/sponsors/elementary/dashboard" target="_blank" rel="noopener">
-                  Manage Sponsorship
-                </a>
-              </li>
-              <li>
-                <a @click="logout">
-                  Log Out
-                </a>
-              </li>
-            </ul>
+        <li>
+          <a href="https://github.com/sponsors/elementary/dashboard" target="_blank" rel="noopener">
+            Manage Sponsorship
+          </a>
+        </li>
+        <li>
+          <a @click="logout">
+            Log Out
+          </a>
+        </li>
+      </ul>
     </nav>
   </header>
 </template>

--- a/pages/sponsor.vue
+++ b/pages/sponsor.vue
@@ -15,6 +15,14 @@
       >
         ♡ Sponsor elementary
       </a>
+      <a
+        class="button"
+        href="https://github.com/sponsors/elementary/dashboard"
+        target="_blank"
+        rel="noopener"
+      >
+        Manage Sponsorship
+      </a>
     </div>
   </div>
 </template>

--- a/pages/sponsor.vue
+++ b/pages/sponsor.vue
@@ -17,7 +17,7 @@
       </a>
       <a
         class="button"
-        href="https://github.com/sponsors/elementary/dashboard"
+        href="https://github.com/sponsors/elementary"
         target="_blank"
         rel="noopener"
       >


### PR DESCRIPTION
Addresses #50 — adds a 'Manage Sponsorship' link/button so sponsors can easily access their GitHub Sponsors dashboard to manage payment methods, tier, etc.

## Changes
- **Navbar**: Added 'Manage Sponsorship' link in the authenticated user dropdown (next to Log Out)
- **Sponsor page**: Added 'Manage Sponsorship' button alongside existing 'Sponsor elementary' and 'Visit elementary.io' buttons
- Both link to  (opens in new tab with )

## Testing
- All CI checks pass locally:  ✅,  ✅,  ✅,  ✅
- Changes follow existing code patterns (Vue 3, Nuxt 3, Pinia, TypeScript)
- No new dependencies added

Fixes #50